### PR TITLE
v1.74.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/protobuf-6.33.0-build-4
+  - https://staging.continuum.io/pbp/fs/lief-feedstock/pr10/1e1d643

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/protobuf-6.33.0-build-4
-  - https://staging.continuum.io/pbp/fs/lief-feedstock/pr10/1e1d643

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "grpcio-status" %}
-{% set version = "1.71.0" %}
+{% set version = "1.74.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 11405fed67b68f406b3f3c7c5ae5104a79d2d309666d10d61b152e91d28fb968
+  sha256: c58c1b24aa454e30f1fc6a7e0dbbc194c54a408143971a94b5f4e40bb5831432
 
 build:
   number: 0
@@ -23,7 +23,7 @@ requirements:
     - wheel
   run:
     - python
-    - protobuf >=5.26.1,<6.0dev
+    - protobuf >=6.31.1,<7.0.0
     - grpcio >={{ version }}
     - googleapis-common-protos >=1.5.5
 


### PR DESCRIPTION
grpc-status v1.74.0. (there was no 1.74.1 released)

**Destination channel:**  defaults

### Links

- [PKG-10682](https://anaconda.atlassian.net/browse/PKG-10682) 
- [Upstream repository](https://github.com/grpc/grpc/tree/v1.74.0/src/python/grpcio_status)
- [artifacts](https://staging.continuum.io/pbp/protobuf-6.33.0-build-4)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/abseil-cpp-feedstock/pull/15
  - https://github.com/AnacondaRecipes/re2-feedstock/pull/6
  - https://github.com/AnacondaRecipes/protobuf-feedstock/pull/28
  - https://github.com/AnacondaRecipes/libprotobuf-feedstock/pull/32
  - https://github.com/AnacondaRecipes/grpc-cpp-feedstock/pull/37
  - https://github.com/AnacondaRecipes/grpcio-status-feedstock/pull/4

### Explanation of changes:

- Bump version and SHA
- Update [protobuf pinning ](https://github.com/grpc/grpc/blob/v1.74.0/src/python/grpcio_status/setup.py#L66)


[PKG-10682]: https://anaconda.atlassian.net/browse/PKG-10682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ